### PR TITLE
Added retries for webpage status verification

### DIFF
--- a/roles/mediawiki/tasks/verify.yml
+++ b/roles/mediawiki/tasks/verify.yml
@@ -3,5 +3,7 @@
   uri:
     url: "http://{{ route.route.spec.host }}"
     return_content: yes
+  retries: 10
+  delay: 5
   register: webpage
-  failed_when: webpage.status != 200
+  until: webpage.status == 200


### PR DESCRIPTION
### Motivation

When running `apb test --dockerfile Dockerfile-canary`, most of the time the verification of the webpage status fails because the page is not ready when the verification role is triggered (`got status 503`)